### PR TITLE
5100 image-gen: Introduce size param. Removed upscale param

### DIFF
--- a/kinds/5100.md
+++ b/kinds/5100.md
@@ -6,7 +6,7 @@ description: Job request to generate Images using AI models.
 
 # Input
 
-Clients must provide a prompt in the <code>"i" </code> tag field. For altering existing images user may optionally provide a second <code>"i"</code> tag containing the url to the existing image 
+Clients must provide a prompt in the <code>"i"</code> tag field. For altering existing images user may optionally provide a second <code>"i"</code> tag containing the url to the existing image 
 
 
 # Params
@@ -38,7 +38,7 @@ Define a negative prompt that includes what the model should avoid during Genera
 ## `size`
 
 Description:
-Specifies the exact image size/dimension that will be generated in the format of `${width}x${ratio}` (i.e `512x512`, `1024x768`). Takes precedence over `ratio`. DVMs SHOULD ignore the job request if unable to fulfill the requested size
+Specifies in the format of `${width}x${ratio}` (i.e `512x512`, `1024x768`) the exact size/dimension the image will be generated in. This param takes precedence over `ratio`. DVMs SHOULD ignore the job request if unable to fulfill the requested size
 
 
 

--- a/kinds/5100.md
+++ b/kinds/5100.md
@@ -38,7 +38,7 @@ Define a negative prompt that includes what the model should avoid during Genera
 ## `size`
 
 Description:
-Specifies in the format of `${width}x${ratio}` (i.e `512x512`, `1024x768`) the exact size/dimension the image will be generated in. This param takes precedence over `ratio`. DVMs SHOULD ignore the job request if unable to fulfill the requested size
+Specifies in the format of `${width}x${height}` (i.e `512x512`, `1024x768`) the exact size/dimension the image will be generated in. This param takes precedence over `ratio`. DVMs SHOULD ignore the job request if unable to fulfill the requested size
 
 
 

--- a/kinds/5100.md
+++ b/kinds/5100.md
@@ -35,10 +35,10 @@ The Ratio of the output image. Allowed ratios are:
 Description:
 Define a negative prompt that includes what the model should avoid during Generation. This sometimes helps improving the outcome quality
 
-## `upscale`
+## `size`
 
 Description:
-Specifies the upscale factor (1-x) DVMS might provide the possiblity to upscale an output image to improve the overall resolution and should use it by default. Users might want to disable or lower upscaling using the parameter.
+Specifies the exact image size/dimension that will be generated in the format of `${width}x${ratio}` (i.e `512x512`, `1024x768`). Takes precedence over `ratio`. DVMs SHOULD ignore the job request if unable to fulfill the requested size
 
 
 
@@ -73,6 +73,7 @@ A link to the generated image(s)
     "tags": [
         [ "i", "https://image.nostr.build/cbfedf544d1ab82d26332bf70c1ea55b8f275ae59a04c3dac175d9cae536725e.jpg", "url" ],
         [ "i", "In style of Pablo Picasso", "text" ]
+        [ "param", "size", "512x512" ]
     ]
 }
 ```


### PR DESCRIPTION
- Introduce `size` param where DVMs have to honor if present
- Removed `upscale` param as it provides ambiguity since it doesn't reference any base dimension. Discussion [here](https://github.com/nostr-protocol/data-vending-machines/issues/6)